### PR TITLE
Quick patch because of Timezone format errors.

### DIFF
--- a/CalFileParser.php
+++ b/CalFileParser.php
@@ -294,8 +294,11 @@ class CalFileParser {
                     $timezone = $this->_file_timezone;
 
                     // found time zone in date format info
-                    if (strstr($date_format,"TZID")) $timezone = substr($date_format, 5);
-
+                    if (strstr($date_format,"TZID")) {
+                        $strstr = strstr($date_format,"TZID");
+                        $timezone = substr($strstr, 5);
+                    }
+                    
                     // process all dates if there are more then one and comma seperated
                     $processed_value = array();
                     foreach(explode(",", $value) AS $date_value) {

--- a/CalFileParser.php
+++ b/CalFileParser.php
@@ -284,7 +284,7 @@ class CalFileParser {
 
                 // autoconvert datetime fields to DateTime object
                 $date_key = (strstr($key,";")) ? strstr($key,";", true) : $key;
-                $date_format = (strstr($key,";")) ? strstr($key,";") : ";VLAUE=DATE-TIME";
+                $date_format = (strstr($key,";")) ? strstr($key,";") : ";VALUE=DATE-TIME";
 
                 if (in_array($date_key, $this->DTfields)) {
 


### PR DESCRIPTION
Sometimes it throws exeption in ths manner: 
Uncaught Exception: DateTimeZone::__construct(): Unknown or bad timezone (=Europe/Prague) in /var/www/html/CalFileParser.php

Note the equal character before timezone. substr($date_format,5) sometimes returns correct timezone name, but sometimes returns timezone with leading semicollon.